### PR TITLE
Differentiate between mob and player damage attribute

### DIFF
--- a/src/com/jedk1/jedcore/ability/firebending/FireBreath.java
+++ b/src/com/jedk1/jedcore/ability/firebending/FireBreath.java
@@ -49,11 +49,11 @@ public class FireBreath extends FireAbility implements AddonAbility {
 	@Attribute(Attribute.DURATION)
 	private long duration;
 	private int particles;
-	@Attribute(Attribute.DAMAGE)
+	@Attribute("Player" + Attribute.DAMAGE)
 	private double playerDamage;
 	@Attribute(Attribute.DAMAGE)
 	private double mobDamage;
-	@Attribute(Attribute.DURATION)
+	@Attribute("Mob" + Attribute.DURATION)
 	private int fireDuration;
 	@Attribute(Attribute.RANGE)
 	private int range;

--- a/src/com/jedk1/jedcore/ability/firebending/FireBreath.java
+++ b/src/com/jedk1/jedcore/ability/firebending/FireBreath.java
@@ -51,9 +51,9 @@ public class FireBreath extends FireAbility implements AddonAbility {
 	private int particles;
 	@Attribute("Player" + Attribute.DAMAGE)
 	private double playerDamage;
-	@Attribute(Attribute.DAMAGE)
+	@Attribute("Mob" + Attribute.DAMAGE)
 	private double mobDamage;
-	@Attribute("Mob" + Attribute.DURATION)
+	@Attribute(Attribute.DURATION)
 	private int fireDuration;
 	@Attribute(Attribute.RANGE)
 	private int range;


### PR DESCRIPTION
Just a small change to differentiate between the 2 different damage attributes in FireBreath.
Since other plugins may depend on certain attributes